### PR TITLE
Fix hardcoded JWT secret — require environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Required — JWT signing secret (min 32 characters)
+# Generate with: node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"
+JWT_SECRET=
+
+# Optional
+PORT=3000
+LOG_LEVEL=info

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,7 +1,21 @@
 import { Request, Response, NextFunction } from "express";
 import jwt from "jsonwebtoken";
 
-const JWT_SECRET = process.env.JWT_SECRET || "super-secret-key-change-in-production";
+function getJwtSecret(): string {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error(
+      "JWT_SECRET environment variable is required. " +
+      "Generate one with: node -e \"console.log(require('crypto').randomBytes(64).toString('hex'))\""
+    );
+  }
+  if (secret.length < 32) {
+    throw new Error("JWT_SECRET must be at least 32 characters long");
+  }
+  return secret;
+}
+
+const JWT_SECRET = getJwtSecret();
 
 export interface AuthRequest extends Request {
   userId?: string;


### PR DESCRIPTION
## Summary

Closes #3 — removes the hardcoded JWT secret fallback that allowed token forgery.

## Security Impact

**Before**: If `JWT_SECRET` env var was unset, the app silently used `"super-secret-key-change-in-production"` — a publicly known string anyone could use to forge admin tokens.

**After**: The server fails fast on startup with a clear error message if `JWT_SECRET` is missing or too short (< 32 chars).

## Changes

- `src/middleware/auth.ts` — replaced fallback with `getJwtSecret()` that validates and throws
- `.env.example` — added documentation for required variables

## Breaking Change

Deployments that relied on the default secret will now fail to start. This is intentional — they were insecure.

## Test Plan

1. Start server without `JWT_SECRET` → should throw with helpful error
2. Start with `JWT_SECRET=short` → should throw (too short)
3. Start with valid 64-char secret → should work normally
4. Verify existing auth flow works end-to-end