### PR TITLE
BREAKING: v2 API with standardized response format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,23 @@ app.use(cors());
 app.use(express.json());
 app.use(morgan("combined"));
 
-// Routes
-app.use("/api/tasks", taskRoutes);
-app.use("/api/users", userRoutes);
+// Routes — v2 API
+app.use("/api/v2/tasks", taskRoutes);
+app.use("/api/v2/users", userRoutes);
+
+// Deprecated v1 routes — redirect to v2
+app.use("/api/tasks", (_req, res) => {
+  res.status(301).json({
+    error: "This endpoint has moved to /api/v2/tasks",
+    migration: "https://github.com/odinro-dev/test-repo/wiki/API-v2-Migration",
+  });
+});
+app.use("/api/users", (_req, res) => {
+  res.status(301).json({
+    error: "This endpoint has moved to /api/v2/users",
+    migration: "https://github.com/odinro-dev/test-repo/wiki/API-v2-Migration",
+  });
+});
 
 // Health check
 app.get("/health", (_req, res) => {

--- a/src/routes/tasks.ts
+++ b/src/routes/tasks.ts
@@ -4,6 +4,7 @@ import { db } from "../db";
 import { CreateTaskInput, UpdateTaskInput, Task } from "../models/task";
 import { AuthRequest, authenticate } from "../middleware/auth";
 import { isNonEmptyString, isValidPriority, isValidStatus, validatePagination, sanitizeString } from "../utils/validation";
+import { sendSuccess, sendError, sendPaginated } from "../utils/response";
 import { logger } from "../utils/logger";
 
 const router = Router();
@@ -11,6 +12,9 @@ const router = Router();
 /**
  * GET /tasks
  * List all tasks with optional filters and pagination.
+ *
+ * Response format (v2):
+ * { success: true, data: [...], pagination: {...}, meta: {...} }
  */
 router.get("/", authenticate, (req: AuthRequest, res: Response) => {
   try {
@@ -29,9 +33,9 @@ router.get("/", authenticate, (req: AuthRequest, res: Response) => {
     }
 
     // Filter by assignee
-    const assignee = req.query.assignee as string;
-    if (assignee) {
-      tasks = tasks.filter((t) => t.assigneeId === assignee);
+    const assigneeId = req.query.assigneeId as string;
+    if (assigneeId) {
+      tasks = tasks.filter((t) => t.assigneeId === assigneeId);
     }
 
     // Filter by tag
@@ -44,11 +48,16 @@ router.get("/", authenticate, (req: AuthRequest, res: Response) => {
     const { page, limit } = validatePagination(req.query.page, req.query.limit);
     const result = db.paginate(tasks, page, limit);
 
-    logger.info("Tasks listed", { count: result.data.length, page, filters: { status, priority, assignee, tag } });
-    res.json(result);
+    logger.info("Tasks listed", { count: result.data.length, page });
+    sendPaginated(res, result.data, {
+      total: result.total,
+      page: result.page,
+      totalPages: result.totalPages,
+      limit,
+    });
   } catch (error) {
     logger.error("Failed to list tasks", { error: (error as Error).message });
-    res.status(500).json({ error: "Internal server error" });
+    sendError(res, "Internal server error");
   }
 });
 
@@ -59,10 +68,10 @@ router.get("/", authenticate, (req: AuthRequest, res: Response) => {
 router.get("/:id", authenticate, (req: AuthRequest, res: Response) => {
   const task = db.getTaskById(req.params.id);
   if (!task) {
-    res.status(404).json({ error: "Task not found" });
+    sendError(res, "Task not found", 404);
     return;
   }
-  res.json(task);
+  sendSuccess(res, task);
 });
 
 /**
@@ -73,12 +82,12 @@ router.post("/", authenticate, (req: AuthRequest, res: Response) => {
   const input: CreateTaskInput = req.body;
 
   if (!isNonEmptyString(input.title)) {
-    res.status(400).json({ error: "Title is required" });
+    sendError(res, "Title is required", 400);
     return;
   }
 
   if (input.priority && !isValidPriority(input.priority)) {
-    res.status(400).json({ error: "Invalid priority value" });
+    sendError(res, "Invalid priority. Must be one of: low, medium, high, critical", 400);
     return;
   }
 
@@ -98,49 +107,50 @@ router.post("/", authenticate, (req: AuthRequest, res: Response) => {
 
   db.createTask(task);
   logger.info("Task created", { taskId: task.id, title: task.title });
-  res.status(201).json(task);
+  sendSuccess(res, task, 201);
 });
 
 /**
- * PATCH /tasks/:id
- * Update an existing task.
+ * PUT /tasks/:id
+ * Full update of an existing task (replaces PATCH).
  */
-router.patch("/:id", authenticate, (req: AuthRequest, res: Response) => {
+router.put("/:id", authenticate, (req: AuthRequest, res: Response) => {
   const existing = db.getTaskById(req.params.id);
   if (!existing) {
-    res.status(404).json({ error: "Task not found" });
+    sendError(res, "Task not found", 404);
     return;
   }
 
   const input: UpdateTaskInput = req.body;
 
   if (input.status && !isValidStatus(input.status)) {
-    res.status(400).json({ error: "Invalid status value" });
+    sendError(res, "Invalid status. Must be one of: todo, in_progress, done, cancelled", 400);
     return;
   }
 
   if (input.priority && !isValidPriority(input.priority)) {
-    res.status(400).json({ error: "Invalid priority value" });
+    sendError(res, "Invalid priority. Must be one of: low, medium, high, critical", 400);
     return;
   }
 
   const updated = db.updateTask(req.params.id, input);
   logger.info("Task updated", { taskId: req.params.id });
-  res.json(updated);
+  sendSuccess(res, updated);
 });
 
 /**
  * DELETE /tasks/:id
- * Delete a task.
+ * Delete a task. Returns the deleted task in the response.
  */
 router.delete("/:id", authenticate, (req: AuthRequest, res: Response) => {
-  const deleted = db.deleteTask(req.params.id);
-  if (!deleted) {
-    res.status(404).json({ error: "Task not found" });
+  const task = db.getTaskById(req.params.id);
+  if (!task) {
+    sendError(res, "Task not found", 404);
     return;
   }
+  db.deleteTask(req.params.id);
   logger.info("Task deleted", { taskId: req.params.id });
-  res.status(204).send();
+  sendSuccess(res, task);
 });
 
 export default router;

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -5,6 +5,7 @@ import { db } from "../db";
 import { CreateUserInput, LoginInput, toPublicUser } from "../models/user";
 import { AuthRequest, authenticate, requireAdmin, generateToken } from "../middleware/auth";
 import { isValidEmail, isNonEmptyString } from "../utils/validation";
+import { sendSuccess, sendError } from "../utils/response";
 import { logger } from "../utils/logger";
 
 const router = Router();
@@ -12,28 +13,31 @@ const router = Router();
 /**
  * POST /users/register
  * Register a new user account.
+ *
+ * Response format changed in v2:
+ * { success: true, data: { user: {...}, token: "..." }, meta: {...} }
  */
 router.post("/register", async (req: Request, res: Response) => {
   const input: CreateUserInput = req.body;
 
   if (!isValidEmail(input.email)) {
-    res.status(400).json({ error: "Invalid email address" });
+    sendError(res, "Invalid email address", 400);
     return;
   }
 
   if (!isNonEmptyString(input.password) || input.password.length < 8) {
-    res.status(400).json({ error: "Password must be at least 8 characters" });
+    sendError(res, "Password must be at least 8 characters", 400);
     return;
   }
 
   if (!isNonEmptyString(input.name)) {
-    res.status(400).json({ error: "Name is required" });
+    sendError(res, "Name is required", 400);
     return;
   }
 
   const existing = db.getUserByEmail(input.email);
   if (existing) {
-    res.status(409).json({ error: "Email already registered" });
+    sendError(res, "Email already registered", 409);
     return;
   }
 
@@ -49,7 +53,7 @@ router.post("/register", async (req: Request, res: Response) => {
 
   const token = generateToken(user.id, user.role);
   logger.info("User registered", { userId: user.id, email: user.email });
-  res.status(201).json({ user: toPublicUser(user), token });
+  sendSuccess(res, { user: toPublicUser(user), token }, 201);
 });
 
 /**
@@ -61,32 +65,33 @@ router.post("/login", async (req: Request, res: Response) => {
 
   const user = db.getUserByEmail(input.email);
   if (!user) {
-    res.status(401).json({ error: "Invalid credentials" });
+    sendError(res, "Invalid credentials", 401);
     return;
   }
 
   const valid = await bcrypt.compare(input.password, user.passwordHash);
   if (!valid) {
-    res.status(401).json({ error: "Invalid credentials" });
+    sendError(res, "Invalid credentials", 401);
     return;
   }
 
   const token = generateToken(user.id, user.role);
   logger.info("User logged in", { userId: user.id });
-  res.json({ user: toPublicUser(user), token });
+  sendSuccess(res, { user: toPublicUser(user), token });
 });
 
 /**
- * GET /users/me
+ * GET /users/profile
  * Get the current authenticated user's profile.
+ * (Renamed from /users/me → /users/profile in v2)
  */
-router.get("/me", authenticate, (req: AuthRequest, res: Response) => {
+router.get("/profile", authenticate, (req: AuthRequest, res: Response) => {
   const user = db.getUserById(req.userId!);
   if (!user) {
-    res.status(404).json({ error: "User not found" });
+    sendError(res, "User not found", 404);
     return;
   }
-  res.json(toPublicUser(user));
+  sendSuccess(res, toPublicUser(user));
 });
 
 /**
@@ -95,21 +100,22 @@ router.get("/me", authenticate, (req: AuthRequest, res: Response) => {
  */
 router.get("/", authenticate, requireAdmin, (_req: AuthRequest, res: Response) => {
   const users = db.getAllUsers().map(toPublicUser);
-  res.json(users);
+  sendSuccess(res, users);
 });
 
 /**
  * DELETE /users/:id
- * Delete a user (admin only).
+ * Delete a user (admin only). Now returns the deleted user instead of 204.
  */
 router.delete("/:id", authenticate, requireAdmin, (req: AuthRequest, res: Response) => {
-  const deleted = db.deleteUser(req.params.id);
-  if (!deleted) {
-    res.status(404).json({ error: "User not found" });
+  const user = db.getUserById(req.params.id);
+  if (!user) {
+    sendError(res, "User not found", 404);
     return;
   }
+  db.deleteUser(req.params.id);
   logger.info("User deleted", { userId: req.params.id, deletedBy: req.userId });
-  res.status(204).send();
+  sendSuccess(res, toPublicUser(user));
 });
 
 export default router;

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -1,0 +1,56 @@
+import { Response } from "express";
+
+/**
+ * Standardized API response wrapper.
+ * All v2 endpoints return responses in this format.
+ */
+export interface ApiResponse<T> {
+  success: boolean;
+  data: T | null;
+  error: string | null;
+  meta: {
+    timestamp: string;
+    requestId?: string;
+  };
+}
+
+export function sendSuccess<T>(res: Response, data: T, statusCode = 200): void {
+  const response: ApiResponse<T> = {
+    success: true,
+    data,
+    error: null,
+    meta: {
+      timestamp: new Date().toISOString(),
+    },
+  };
+  res.status(statusCode).json(response);
+}
+
+export function sendError(res: Response, message: string, statusCode = 500): void {
+  const response: ApiResponse<null> = {
+    success: false,
+    data: null,
+    error: message,
+    meta: {
+      timestamp: new Date().toISOString(),
+    },
+  };
+  res.status(statusCode).json(response);
+}
+
+export function sendPaginated<T>(
+  res: Response,
+  data: T[],
+  pagination: { total: number; page: number; totalPages: number; limit: number }
+): void {
+  const response = {
+    success: true,
+    data,
+    error: null,
+    pagination,
+    meta: {
+      timestamp: new Date().toISOString(),
+    },
+  };
+  res.json(response);
+}


### PR DESCRIPTION
## Summary

Introduces API v2 with a consistent response envelope and updated endpoint paths.

## Breaking Changes

| v1 | v2 | Notes |
|----|-----|-------|
| `GET /api/tasks` | `GET /api/v2/tasks` | New response wrapper |
| `PATCH /api/tasks/:id` | `PUT /api/v2/tasks/:id` | HTTP method changed |
| `GET /api/users/me` | `GET /api/v2/users/profile` | Path renamed |
| `DELETE /api/tasks/:id` | `DELETE /api/v2/tasks/:id` | Now returns deleted resource |
| `?assignee=` | `?assigneeId=` | Query param renamed |

## New Response Format

All responses now follow:
\`\`\`json
{
  "success": true,
  "data": { ... },
  "error": null,
  "meta": { "timestamp": "2024-01-15T..." }
}
\`\`\`

Paginated responses add a \`pagination\` field.

## Migration

Old v1 endpoints return `301` with a link to the migration guide.