### PR TITLE
Add version and node info to health check endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,12 @@ app.use("/api/users", userRoutes);
 
 // Health check
 app.get("/health", (_req, res) => {
-  res.json({ status: "ok", uptime: process.uptime() });
+  res.json({
+    status: "ok",
+    uptime: process.uptime(),
+    version: process.env.npm_package_version || "unknown",
+    nodeVersion: process.version,
+  });
 });
 
 // 404 handler


### PR DESCRIPTION
Hi! This is my first contribution to this project.

I noticed the health check endpoint only returns the uptime. I added the package version and Node.js version to help with debugging in production.

Let me know if any changes are needed!