### PR TITLE
Add request ID tracking middleware

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import express from "express";
 import cors from "cors";
 import helmet from "helmet";
 import morgan from "morgan";
+import { v4 as uuidv4 } from "uuid";
 import taskRoutes from "./routes/tasks";
 import userRoutes from "./routes/users";
 import { logger } from "./utils/logger";
@@ -15,13 +16,23 @@ app.use(cors());
 app.use(express.json());
 app.use(morgan("combined"));
 
+// Request ID middleware
+app.use((req, _res, next) => {
+  (req as any).requestId = req.headers["x-request-id"] || uuidv4();
+  next();
+});
+
 // Routes
 app.use("/api/tasks", taskRoutes);
 app.use("/api/users", userRoutes);
 
 // Health check
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", uptime: process.uptime() });
+app.get("/health", (req, res) => {
+  res.json({
+    status: "ok",
+    uptime: process.uptime(),
+    requestId: (req as any).requestId,
+  });
 });
 
 // 404 handler
@@ -30,9 +41,10 @@ app.use((_req, res) => {
 });
 
 // Error handler
-app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
-  logger.error("Unhandled error", { error: err.message, stack: err.stack });
-  res.status(500).json({ error: "Internal server error" });
+app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  const requestId = (req as any).requestId;
+  logger.error("Unhandled error", { requestId, error: err.message, stack: err.stack });
+  res.status(500).json({ error: "Internal server error", requestId });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary

Adds request ID tracking for observability and distributed tracing.

## Changes

- New middleware generates a UUID per request (or reuses `X-Request-ID` header)
- Request ID included in health check and error responses
- Request ID logged with errors for correlation

## Context

When debugging production issues, we need to correlate log entries with specific requests. This is standard practice for any API that will be deployed behind a load balancer.

## Test Plan

- [ ] Requests without `X-Request-ID` get a generated UUID
- [ ] Requests with `X-Request-ID` header reuse the provided value
- [ ] Health check response includes `requestId`
- [ ] Error responses include `requestId`