### PR TITLE
Update dependencies and tighten TypeScript config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "task-manager-api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A simple task manager REST API",
   "main": "dist/index.js",
   "scripts": {
@@ -8,28 +8,35 @@
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts",
     "lint": "eslint src/",
-    "test": "jest"
+    "test": "jest",
+    "format": "prettier --write src/",
+    "format:check": "prettier --check src/"
   },
   "dependencies": {
-    "express": "^4.18.2",
-    "uuid": "^9.0.0",
+    "express": "^4.21.0",
+    "uuid": "^10.0.0",
     "bcrypt": "^5.1.1",
     "jsonwebtoken": "^9.0.2",
     "cors": "^2.8.5",
-    "helmet": "^7.1.0",
-    "morgan": "^1.10.0"
+    "helmet": "^8.0.0",
+    "morgan": "^1.10.0",
+    "express-rate-limit": "^7.4.0"
   },
   "devDependencies": {
-    "@types/express": "^4.17.21",
-    "@types/node": "^20.10.0",
-    "@types/uuid": "^9.0.7",
+    "@types/express": "^5.0.0",
+    "@types/node": "^22.0.0",
+    "@types/uuid": "^10.0.0",
     "@types/bcrypt": "^5.0.2",
-    "@types/jsonwebtoken": "^9.0.5",
+    "@types/jsonwebtoken": "^9.0.7",
     "@types/cors": "^2.8.17",
     "@types/morgan": "^1.9.9",
-    "typescript": "^5.3.2",
+    "typescript": "^5.6.0",
     "ts-node": "^10.9.2",
     "jest": "^29.7.0",
-    "eslint": "^8.55.0"
+    "eslint": "^9.0.0",
+    "prettier": "^3.4.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
@@ -12,7 +12,10 @@
     "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

Routine dependency updates and stricter TypeScript configuration.

## Dependency Changes

| Package | Old | New | Notes |
|---------|-----|-----|-------|
| express | 4.18 | 4.21 | Security patches |
| uuid | 9.x | 10.x | Major version bump |
| helmet | 7.x | 8.x | Major version bump |
| eslint | 8.x | 9.x | Major — flat config format |
| typescript | 5.3 | 5.6 | New features |
| @types/express | 4.x | 5.x | Major |
| @types/node | 20 | 22 | Match runtime |

## New Dependencies

- `express-rate-limit` — for #8
- `prettier` — code formatting

## TypeScript

- Target bumped to ES2022
- Added `noUnusedLocals`, `noUnusedParameters`, `noFallthroughCasesInSwitch`
- May surface new lint errors in existing code

## Risk

Major version bumps for `uuid`, `helmet`, `eslint`, and `@types/express` may require migration steps. Haven't tested all code paths yet.