### PR TITLE
Add overdue and due-soon task filters

### DIFF
--- a/src/routes/tasks.ts
+++ b/src/routes/tasks.ts
@@ -60,7 +60,7 @@ router.get("/", authenticate, (req: AuthRequest, res: Response) => {
     const { page, limit } = validatePagination(req.query.page, req.query.limit);
     const result = db.paginate(tasks, page, limit);
 
-    logger.info("Tasks listed", { count: result.data.length, page, filters: { status, priority, assignee, tag } });
+    logger.info("Tasks listed", { count: result.data.length, page, filters: { status, priority, assignee, tag, overdue, dueSoon } });
     res.json(result);
   } catch (error) {
     logger.error("Failed to list tasks", { error: (error as Error).message });

--- a/src/routes/tasks.ts
+++ b/src/routes/tasks.ts
@@ -44,7 +44,16 @@ router.get("/", authenticate, (req: AuthRequest, res: Response) => {
     const overdue = req.query.overdue as string;
     if (overdue === "true") {
       const now = new Date();
-      tasks = tasks.filter((t) => t.dueDate && new Date(t.dueDate) < now && t.status !== "done");
+      tasks = tasks.filter((t) => t.dueDate && new Date(t.dueDate) < now && t.status !== "done" && t.status !== "cancelled");
+    }
+
+    // Filter tasks due soon
+    const dueSoon = req.query.dueSoon as string;
+    if (dueSoon) {
+      const days = parseInt(dueSoon, 10) || 3;
+      const now = new Date();
+      const cutoff = new Date(now.getTime() + days * 24 * 60 * 60 * 1000);
+      tasks = tasks.filter((t) => t.dueDate && new Date(t.dueDate) >= now && new Date(t.dueDate) <= cutoff);
     }
 
     // Pagination

--- a/src/routes/tasks.ts
+++ b/src/routes/tasks.ts
@@ -40,6 +40,13 @@ router.get("/", authenticate, (req: AuthRequest, res: Response) => {
       tasks = tasks.filter((t) => t.tags.includes(tag));
     }
 
+    // Filter overdue tasks
+    const overdue = req.query.overdue as string;
+    if (overdue === "true") {
+      const now = new Date();
+      tasks = tasks.filter((t) => t.dueDate && new Date(t.dueDate) < now && t.status !== "done");
+    }
+
     // Pagination
     const { page, limit } = validatePagination(req.query.page, req.query.limit);
     const result = db.paginate(tasks, page, limit);


### PR DESCRIPTION
refs #11

Added filtering for:
- \`?overdue=true\` — tasks past due date (excluding done/cancelled)
- \`?dueSoon=N\` — tasks due within N days (default 3)

Still need to:
- [ ] Add isOverdue computed field to response
- [ ] Sort overdue by how far past due