### PR TITLE
fix: stable cursor pagination for tasks (closes #1)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -96,8 +96,28 @@ curl -H "Authorization: Bearer $TOKEN" \
   ],
   "total": 1,
   "page": 1,
-  "totalPages": 1
+  "totalPages": 1,
+  "nextCursor": null
 }
+```
+
+**Pagination**
+
+`GET /api/tasks` supports two modes:
+
+- **Offset** (default): `?page=<n>&limit=<n>` (default `limit=20`, max `100`). Results are ordered by a stable `(createdAt, id)` key, so each page is deterministic. Offset paging is convenient, but it can still skip a row if tasks are *deleted* while you page through the list — prefer cursor paging for full traversals.
+- **Cursor** (recommended for full traversals): `?cursor=<nextCursor>&limit=<n>`. Every response includes a `nextCursor`; pass it on the next request to fetch the rows immediately after the last one you received. A `null` `nextCursor` means you've reached the end. Because each page is anchored to a row key rather than a numeric offset, every task is returned exactly once even when tasks are created or deleted between requests.
+
+```bash
+# Walk the entire list safely with cursor pagination
+cursor=""
+while :; do
+  resp=$(curl -s -H "Authorization: Bearer $TOKEN" \
+    "http://localhost:3000/api/tasks?limit=10&cursor=$cursor")
+  echo "$resp" | jq '.data[].id'
+  cursor=$(echo "$resp" | jq -r '.nextCursor // empty')
+  [ -z "$cursor" ] && break
+done
 ```
 
 ### Create Task

--- a/scripts/verify-pagination.ts
+++ b/scripts/verify-pagination.ts
@@ -1,0 +1,86 @@
+/**
+ * Standalone reproduction / regression check for issue #1:
+ * pagination must return every task exactly once even when tasks are
+ * created or deleted partway through a traversal.
+ *
+ * Run with:  npx ts-node scripts/verify-pagination.ts
+ * Exits non-zero if the invariant is violated.
+ */
+import { db } from "../src/db";
+import { decodeCursor } from "../src/utils/cursor";
+import { Task } from "../src/models/task";
+
+function makeTask(seq: number): Task {
+  // Strictly increasing createdAt so the (createdAt, id) order is well defined.
+  const ts = new Date(1_700_000_000_000 + seq * 1000).toISOString();
+  return {
+    id: `t-${String(seq).padStart(3, "0")}`,
+    title: `Task ${seq}`,
+    description: "",
+    status: "todo",
+    priority: "medium",
+    assigneeId: null,
+    tags: [],
+    dueDate: null,
+    createdAt: ts,
+    updatedAt: ts,
+  };
+}
+
+const failures: string[] = [];
+function check(cond: boolean, msg: string): void {
+  if (!cond) failures.push(msg);
+}
+
+const LIMIT = 10;
+
+// 1. Seed 25 tasks (t-001 .. t-025).
+for (let i = 1; i <= 25; i++) db.createTask(makeTask(i));
+
+// 2. Read page 1 in cursor mode.
+const page1 = db.queryTasksByCursor({ limit: LIMIT });
+const seen: string[] = page1.data.map((t) => t.id);
+check(page1.data.length === LIMIT, `page 1 should have ${LIMIT} items, got ${page1.data.length}`);
+
+// 3. Concurrent modifications between page 1 and page 2 — the exact hazard
+//    from issue #1, made deliberately adversarial for OFFSET pagination:
+//      a) insert a task that sorts to the FRONT (earliest createdAt). Under
+//         offset paging this shifts every later row down by one -> the last
+//         row of page 1 would reappear on page 2 (duplicate).
+//      b) delete a task we already returned on page 1. Under offset paging
+//         this shifts later rows up by one -> a row gets skipped.
+db.createTask(makeTask(0)); // t-000, sorts before everything (before the cursor)
+db.deleteTask(page1.data[3].id); // remove the 4th already-seen row (t-004)
+
+// 4. Walk the remaining pages strictly after the cursor.
+let cursor = page1.nextCursor;
+let guard = 0;
+while (cursor && guard++ < 1000) {
+  const decoded = decodeCursor(cursor);
+  check(decoded !== null, `nextCursor should decode, got ${cursor}`);
+  const pageRes = db.queryTasksByCursor({ limit: LIMIT, cursor: decoded ?? undefined });
+  seen.push(...pageRes.data.map((t) => t.id));
+  cursor = pageRes.nextCursor;
+}
+
+// 5. Invariants.
+const unique = new Set(seen);
+const duplicates = seen.filter((id, i) => seen.indexOf(id) !== i);
+
+check(duplicates.length === 0, `no task should appear twice; duplicates: ${[...new Set(duplicates)].join(", ")}`);
+
+// Every task that existed at the moment we read its page must be covered exactly
+// once: t-001..t-025 (t-004 was returned on page 1 before deletion). The
+// front-inserted t-000 sorts before the cursor, so it is correctly NOT revisited.
+const expected = Array.from({ length: 25 }, (_, i) => `t-${String(i + 1).padStart(3, "0")}`);
+const missing = expected.filter((id) => !unique.has(id));
+check(missing.length === 0, `no task should be skipped; missing: ${missing.join(", ")}`);
+check(!unique.has("t-000"), "t-000 was inserted behind the cursor and must not be revisited");
+check(seen.length === 25, `expected 25 total reads, got ${seen.length}`);
+
+if (failures.length > 0) {
+  console.error("FAIL — pagination invariant violated:");
+  for (const f of failures) console.error("  - " + f);
+  process.exit(1);
+}
+console.log("PASS — 25 tasks traversed exactly once across pages despite a mid-traversal insert + delete.");

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,5 +1,6 @@
 import { Task } from "./models/task";
 import { User } from "./models/user";
+import { encodeCursor, Cursor } from "./utils/cursor";
 
 export interface TaskQuery {
   status?: string;
@@ -8,6 +9,49 @@ export interface TaskQuery {
   tag?: string;
   page: number;
   limit: number;
+}
+
+export interface TaskCursorQuery {
+  status?: string;
+  priority?: string;
+  assignee?: string;
+  tag?: string;
+  limit: number;
+  cursor?: Cursor;
+}
+
+/**
+ * Stable, total ordering for tasks: chronological by `createdAt`, with `id` as
+ * a deterministic tiebreaker for tasks created within the same millisecond.
+ * Cursor pagination relies on this being a *total* order so a cursor splits the
+ * collection unambiguously into "already seen" and "not yet seen".
+ */
+function compareByKey(
+  a: { createdAt: string; id: string },
+  b: { createdAt: string; id: string }
+): number {
+  if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? -1 : 1;
+  if (a.id !== b.id) return a.id < b.id ? -1 : 1;
+  return 0;
+}
+
+/**
+ * Insert `task` into an ascending-sorted `window`, keeping at most `cap` of the
+ * smallest items. This lets us page without materializing the whole match set:
+ * memory stays at O(cap) regardless of collection size — preserving the
+ * per-request memory ceiling from issue #34 even though the Map is unsorted.
+ */
+function insertCapped(window: Task[], task: Task, cap: number): void {
+  if (cap <= 0) return;
+  let lo = 0;
+  let hi = window.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (compareByKey(window[mid], task) < 0) lo = mid + 1;
+    else hi = mid;
+  }
+  window.splice(lo, 0, task);
+  if (window.length > cap) window.pop();
 }
 
 /**
@@ -28,30 +72,76 @@ class Database {
   }
 
   /**
-   * Filter and paginate tasks in a single pass over the task map.
+   * Offset pagination over a *stable* (createdAt, id) ordering.
    *
-   * Unlike getAllTasks().filter(...).slice(...), this never materializes the
-   * full collection per request — it only collects the requested page window
-   * (<= limit items) plus a running match count. That keeps per-request
-   * allocation at O(page_size) instead of O(total_tasks), which is what was
-   * exhausting the heap under sustained list traffic (issue #34).
+   * The previous implementation paged in raw Map-insertion order with no sort,
+   * so any concurrent insert/delete before the page boundary duplicated or
+   * skipped rows across pages (issue #1). Sorting by a total key makes the
+   * offset deterministic and removes the insert-duplicate case (new rows sort
+   * to the end). Caveat: offset paging still cannot guarantee "exactly once"
+   * when rows are *deleted* mid-traversal — clients that need that guarantee
+   * should use the cursor path (`queryTasksByCursor`).
+   *
+   * Memory stays at O(end) via a bounded sorted window (see insertCapped),
+   * keeping the per-request ceiling introduced for issue #34.
    */
-  queryTasks(query: TaskQuery): { data: Task[]; total: number; page: number; totalPages: number } {
+  queryTasks(
+    query: TaskQuery
+  ): { data: Task[]; total: number; page: number; totalPages: number; nextCursor: string | null } {
     const { status, priority, assignee, tag, page, limit } = query;
     const start = (page - 1) * limit;
     const end = start + limit;
-    const data: Task[] = [];
+    const window: Task[] = [];
     let total = 0;
     for (const task of this.tasks.values()) {
       if (status && task.status !== status) continue;
       if (priority && task.priority !== priority) continue;
       if (assignee && task.assigneeId !== assignee) continue;
       if (tag && !task.tags.includes(tag)) continue;
-      // Only the rows on the requested page are retained in memory.
-      if (total >= start && total < end) data.push(task);
       total++;
+      // Retain only the smallest `end` matches needed to build this page.
+      insertCapped(window, task, end);
     }
-    return { data, total, page, totalPages: Math.ceil(total / limit) };
+    const data = window.slice(start, end);
+    const totalPages = Math.ceil(total / limit);
+    const last = data[data.length - 1];
+    const nextCursor =
+      last && page < totalPages ? encodeCursor({ createdAt: last.createdAt, id: last.id }) : null;
+    return { data, total, page, totalPages, nextCursor };
+  }
+
+  /**
+   * Cursor (keyset) pagination — the stable fix for issue #1.
+   *
+   * Returns up to `limit` matching tasks that sort strictly after `cursor` in
+   * (createdAt, id) order. Because the page is anchored to a row's key rather
+   * than a numeric offset, inserts or deletes that happen *before* the cursor
+   * between requests can't shift the window — every task is returned exactly
+   * once across the traversal. Memory stays at O(limit) via insertCapped.
+   */
+  queryTasksByCursor(
+    query: TaskCursorQuery
+  ): { data: Task[]; total: number; nextCursor: string | null } {
+    const { status, priority, assignee, tag, limit, cursor } = query;
+    const window: Task[] = [];
+    let total = 0;
+    let afterCursor = 0;
+    for (const task of this.tasks.values()) {
+      if (status && task.status !== status) continue;
+      if (priority && task.priority !== priority) continue;
+      if (assignee && task.assigneeId !== assignee) continue;
+      if (tag && !task.tags.includes(tag)) continue;
+      total++;
+      if (cursor && compareByKey(task, cursor) <= 0) continue; // already seen
+      afterCursor++;
+      insertCapped(window, task, limit);
+    }
+    const last = window[window.length - 1];
+    const nextCursor =
+      afterCursor > limit && last
+        ? encodeCursor({ createdAt: last.createdAt, id: last.id })
+        : null;
+    return { data: window, total, nextCursor };
   }
 
   getTasksByStatus(status: string): Task[] {
@@ -107,19 +197,6 @@ class Database {
 
   deleteUser(id: string): boolean {
     return this.users.delete(id);
-  }
-
-  // Pagination helper
-  paginate<T>(items: T[], page: number, limit: number): { data: T[]; total: number; page: number; totalPages: number } {
-    const start = (page - 1) * limit;
-    const end = start + limit;
-    const data = items.slice(start, end);
-    return {
-      data,
-      total: items.length,
-      page,
-      totalPages: Math.ceil(items.length / limit),
-    };
   }
 }
 

--- a/src/routes/tasks.ts
+++ b/src/routes/tasks.ts
@@ -4,13 +4,23 @@ import { db } from "../db";
 import { CreateTaskInput, UpdateTaskInput, Task } from "../models/task";
 import { AuthRequest, authenticate } from "../middleware/auth";
 import { isNonEmptyString, isValidPriority, isValidStatus, validatePagination, sanitizeString } from "../utils/validation";
+import { decodeCursor, Cursor } from "../utils/cursor";
 import { logger } from "../utils/logger";
 
 const router = Router();
 
 /**
  * GET /tasks
- * List all tasks with optional filters and pagination.
+ * List tasks with optional filters and pagination.
+ *
+ * Two pagination modes (both filter + page inside the data layer so a request
+ * only materializes the page it returns — issue #34):
+ *   - Offset (default): `?page=&limit=`. Backward compatible; now ordered by a
+ *     stable (createdAt, id) key so results are deterministic.
+ *   - Cursor (recommended): `?cursor=&limit=`. Keyset pagination that returns
+ *     each task exactly once even when tasks are created/deleted mid-traversal
+ *     (issue #1). Pass back the `nextCursor` from the previous response; a null
+ *     `nextCursor` means the last page.
  */
 router.get("/", authenticate, (req: AuthRequest, res: Response) => {
   try {
@@ -20,11 +30,30 @@ router.get("/", authenticate, (req: AuthRequest, res: Response) => {
     const tag = req.query.tag as string;
     const { page, limit } = validatePagination(req.query.page, req.query.limit);
 
-    // Filter + paginate inside the data layer so a request only materializes the
-    // page it returns, instead of copying the whole task collection per request
-    // (the O(N)-per-request allocation behind issue #34).
-    const result = db.queryTasks({ status, priority, assignee, tag, page, limit });
+    // Cursor mode is selected by the presence of the `cursor` param. An empty
+    // value (`?cursor=`) means "start from the beginning" in cursor mode.
+    const rawCursor = req.query.cursor;
+    if (rawCursor !== undefined) {
+      if (typeof rawCursor !== "string") {
+        res.status(400).json({ error: "Invalid cursor" });
+        return;
+      }
+      let cursor: Cursor | undefined;
+      if (rawCursor !== "") {
+        const decoded = decodeCursor(rawCursor);
+        if (!decoded) {
+          res.status(400).json({ error: "Invalid cursor" });
+          return;
+        }
+        cursor = decoded;
+      }
+      const result = db.queryTasksByCursor({ status, priority, assignee, tag, limit, cursor });
+      logger.info("Tasks listed (cursor)", { count: result.data.length, filters: { status, priority, assignee, tag } });
+      res.json(result);
+      return;
+    }
 
+    const result = db.queryTasks({ status, priority, assignee, tag, page, limit });
     logger.info("Tasks listed", { count: result.data.length, page, filters: { status, priority, assignee, tag } });
     res.json(result);
   } catch (error) {

--- a/src/utils/cursor.ts
+++ b/src/utils/cursor.ts
@@ -1,0 +1,41 @@
+/**
+ * Opaque cursor encoding for keyset (cursor-based) pagination.
+ *
+ * A cursor captures the stable sort key of the last item a client has already
+ * seen: `(createdAt, id)`. The next page returns rows strictly greater than
+ * that key in `(createdAt, id)` order, which is immune to inserts and deletes
+ * happening *before* the cursor between requests — the root cause of issue #1.
+ *
+ * The wire format is an opaque base64url string so clients treat it as a blob
+ * and don't build dependencies on its internal shape.
+ */
+
+export interface Cursor {
+  createdAt: string;
+  id: string;
+}
+
+const SEPARATOR = "|";
+
+export function encodeCursor(cursor: Cursor): string {
+  const raw = `${cursor.createdAt}${SEPARATOR}${cursor.id}`;
+  return Buffer.from(raw, "utf8").toString("base64url");
+}
+
+/**
+ * Decode an opaque cursor. Returns null for any malformed input so callers can
+ * reject it with a 400 rather than silently paginate from a garbage anchor.
+ */
+export function decodeCursor(raw: string): Cursor | null {
+  try {
+    const decoded = Buffer.from(raw, "base64url").toString("utf8");
+    const sep = decoded.indexOf(SEPARATOR);
+    if (sep === -1) return null;
+    const createdAt = decoded.slice(0, sep);
+    const id = decoded.slice(sep + 1);
+    if (!createdAt || !id) return null;
+    return { createdAt, id };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the duplicate/skip behavior in `GET /api/tasks` pagination reported in #1.

The endpoint paged over `this.tasks.values()` (Map **insertion order, no sort**) and sliced by a numeric offset `start = (page - 1) * limit`. Offset pagination over a live, mutable collection is inherently unstable:

- an **insert** before the page boundary shifts rows down → a row reappears on the next page (**duplicate**);
- a **delete** before the boundary shifts rows up → a row is jumped over (**skip**).

So the issue's *Expected Behavior* — "each task appears exactly once **regardless of concurrent modifications**" — can't be met by offset pagination at all.

## Why this differs from #16

PR #16 patches `Database.paginate()`, but that method is **dead code** — `grep -rn "paginate(" src/` shows zero call sites; the endpoint uses `queryTasks()`. Even if it were wired in, stable-sort + offset only prevents the *insert→duplicate* case (new rows sort last); a *delete* before the boundary still skips a row. This PR fixes the method that actually runs and uses keyset pagination so the "exactly once" guarantee actually holds. **Recommend closing #16 in favor of this.**

## Changes

- **Stable ordering** by `(createdAt, id)` (chronological, with `id` as a same-millisecond tiebreaker).
- **Cursor (keyset) pagination**: `?cursor=<nextCursor>&limit=` returns rows strictly after the cursor; every response carries a `nextCursor` (`null` on the last page). Immune to inserts/deletes before the cursor.
- **Offset stays backward compatible**: `?page=&limit=` still works, now deterministically ordered, and also returns `nextCursor`.
- Removed the unused `Database.paginate()` footgun.
- Bounded sorted window keeps per-request memory at **O(page)** — preserving the heap ceiling from #34 (no full-collection materialization).
- `docs/API.md` documents both modes; `scripts/verify-pagination.ts` reproduces the issue scenario.

## Testing

- `npm run build` — passes (tsc, strict).
- `npx ts-node --transpile-only scripts/verify-pagination.ts` — seeds 25 tasks, then **inserts a front-sorting task and deletes an already-returned task between pages** (the adversarial case for offset paging), and asserts every task is traversed exactly once:

  ```
  PASS — 25 tasks traversed exactly once across pages despite a mid-traversal insert + delete.
  ```

> Note: `npm run lint` fails on `main` too (no ESLint config in the repo); unrelated to this change.

## Compatibility

Additive only. Existing `?page=/?limit=` clients keep working; the response gains a `nextCursor` field. No breaking changes.

Closes #1
